### PR TITLE
Autopmpermit Bug Fixes + minor adjustments

### DIFF
--- a/commands/allow.js
+++ b/commands/allow.js
@@ -5,7 +5,7 @@ const pmpermit = require("../helpers/pmpermit");
 const execute = async (client, msg) => {
   if (config.pmpermit_enabled == "true" && !msg.to.includes("-")) {
     await pmpermit.permit(msg.to.split("@")[0]);
-    msg.reply("Allowed for PM");
+    msg.reply("*WhatsBot_Notification - ✅ Allowed*\n\nYou are allowed for PM");
   }
 };
 

--- a/commands/block.js
+++ b/commands/block.js
@@ -1,7 +1,10 @@
 //jshint esversion:8
 const execute = async (client, msg) => {
   if (!msg.to.includes("-")) {
-    await (await msg.getContact()).block();
+    await msg.reply(`*WhatsBot_Notification - ❌ Blocked* \n\n You have been blocked`);
+    let chat = await msg.getChat();
+    let contact = await chat.getContact();
+    contact.block();
   }
 };
 

--- a/commands/mute.js
+++ b/commands/mute.js
@@ -7,7 +7,7 @@ const execute = async (client, msg) => {
     let unmuteDate = new Date();
     unmuteDate.setSeconds(Number(unmuteDate.getSeconds()) + 3600);
     await chat.mute(unmuteDate);
-    msg.reply(`You have been muted for 1 hour`);
+    msg.reply(`*WhatsBot_Notification - 🤫 Muted*\n\nYou have been muted for 1 hour`);
   }
 };
 

--- a/commands/nopm.js
+++ b/commands/nopm.js
@@ -5,7 +5,7 @@ const pmpermit = require("../helpers/pmpermit");
 const execute = async (client, msg) => {
   if (config.pmpermit_enabled == "true" && !msg.to.includes("-")) {
     await pmpermit.nopermit(msg.to.split("@")[0]);
-    msg.reply("Not Allowed for PM"); // don't change this text without discussion with Tuhin
+    msg.reply("*WhatsBot_Notification - ⛔ Not Allowed*\n\nYou are not allowed for PM"); // don't change this text without discussion with Tuhin
   }
 };
 

--- a/commands/unmute.js
+++ b/commands/unmute.js
@@ -3,7 +3,7 @@ const execute = async (client,msg) => {
     if (!msg.to.includes("-")) {
         let chat = await msg.getChat();
         await chat.unmute(true);
-        msg.reply(`You have been unmuted`);
+        msg.reply(`*WhatsBot_Notification - 🗣 Unmuted*\n\nYou have been unmuted`);
     }
 };
 

--- a/helpers/pmpermit.js
+++ b/helpers/pmpermit.js
@@ -107,14 +107,14 @@ async function handler(id) {
     return {
       permit: false,
       block: false,
-      msg: `*✋ Wait*\n\nPlease wait until I will get back to Online, Kindly don't send another message.`,
+      msg: `*WhatsBot_Notification - ✋ Wait*\n\n Please wait until I will get back to Online, Kindly don't send another message.`,
     };
   } else if (checkPermit.found && !checkPermit.permit) {
     if (checkPermit.times > 3) {
       return {
         permit: false,
         block: true,
-        msg: `*✋ Blocked*\n\nYou have been blocked for spamming.`,
+        msg: `*WhatsBot_Notification - ❌ Blocked*\n\n You have been blocked for spamming.`,
       };
     } else {
       var updateIt = await updateviolant(id, checkPermit.times + 1);
@@ -126,7 +126,7 @@ async function handler(id) {
       return {
         permit: false,
         block: false,
-        msg: `*✋ Wait*\n\nPlease wait until I will get back to Online, Kindly don't send another message. You have ${checkPermit.times} warning(s).`,
+        msg: `*WhatsBot_Notification - ✋ Wait*\n\nPlease wait until I will get back to Online, Kindly don't send another message. You have ${checkPermit.times} warning(s).`,
       };
     }
   } else {

--- a/main.js
+++ b/main.js
@@ -44,7 +44,7 @@ client.on("message", async (msg) => {
     if (!checkIfAllowed.permit) {
       // if not permitted
       if (checkIfAllowed.block) {
-        msg.reply(checkIfAllowed.msg);
+        // await msg.reply(checkIfAllowed.msg);
         await (await msg.getContact()).block();
       } else if (!checkIfAllowed.block) {
         msg.reply(checkIfAllowed.msg);
@@ -55,16 +55,20 @@ client.on("message", async (msg) => {
 
 client.on("message_create", async (msg) => {
   // auto pmpermit
+  console.log(msg);
   try {
     if (config.pmpermit_enabled == "true") {
       var otherChat = await (await msg.getChat()).getContact();
       if (
+        msg.fromMe &&
+        msg.type !== "notification_template" &&
         otherChat.isUser &&
         !(await pmpermit.isPermitted(otherChat.number)) &&
         !otherChat.isMe &&
         !msg.body.startsWith("!nopm") &&
-        msg.body !== "Not Allowed for PM"
+        !msg.body.startsWith("*WhatsBot_Notification")
       ) {
+        console.log(msg.body);
         await pmpermit.permit(otherChat.number);
         await logger(
           client,

--- a/main.js
+++ b/main.js
@@ -66,7 +66,7 @@ client.on("message_create", async (msg) => {
         otherChat.isUser &&
         !(await pmpermit.isPermitted(otherChat.number)) &&
         !otherChat.isMe &&
-        !msg.body.startsWith("!nopm") &&
+        !msg.body.startsWith("!") &&
         !msg.body.startsWith("*WhatsBot_Notification")
       ) {
         await pmpermit.permit(otherChat.number);

--- a/main.js
+++ b/main.js
@@ -44,8 +44,10 @@ client.on("message", async (msg) => {
     if (!checkIfAllowed.permit) {
       // if not permitted
       if (checkIfAllowed.block) {
-        // await msg.reply(checkIfAllowed.msg);
-        await (await msg.getContact()).block();
+        await msg.reply(checkIfAllowed.msg);
+        setTimeout(async () => {
+          await (await msg.getContact()).block();
+        }, 3000);
       } else if (!checkIfAllowed.block) {
         msg.reply(checkIfAllowed.msg);
       }
@@ -55,7 +57,6 @@ client.on("message", async (msg) => {
 
 client.on("message_create", async (msg) => {
   // auto pmpermit
-  console.log(msg);
   try {
     if (config.pmpermit_enabled == "true") {
       var otherChat = await (await msg.getChat()).getContact();
@@ -68,7 +69,6 @@ client.on("message_create", async (msg) => {
         !msg.body.startsWith("!nopm") &&
         !msg.body.startsWith("*WhatsBot_Notification")
       ) {
-        console.log(msg.body);
         await pmpermit.permit(otherChat.number);
         await logger(
           client,


### PR DESCRIPTION
## Following bugs were found and resolved -

1. Autopermit executing in unintended cases. - The auto permit was intended to be invoked when the client user directly texts a chat which is not permitted yet. This was working fine for the intended case. But it was also being called in some unintended situations.
    -  It was responding to the other user's messages as well.
    -  it was responding to the wait messages sent by the bot when a non permitted user texts the client.
    -  it was also responding to the grey "you blocked this contact" notification.

2. The `!block` command was blocking the client itself instead of the chat.

### Fixes

1. Auto pm permit was missing certain conditions which were added. All notification messages sent by admin commands now have a `WhatsBot_Notification` heading so that they can be recognised by auto pm permit.
```
if (
        msg.fromMe &&
        msg.type !== "notification_template" &&
        otherChat.isUser &&
        !(await pmpermit.isPermitted(otherChat.number)) &&
        !otherChat.isMe &&
        !msg.body.startsWith("!") &&
        !msg.body.startsWith("*WhatsBot_Notification")
      ) {
```
2.`!block` was reverted to its previous implementation.

### Minor adjustments

The block action taken after 3 warnings now has a timeout of 3 seconds to ensure that the notification is successfully sent to the contact.
